### PR TITLE
change React Router dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bows": "^1.3.2",
     "lodash-node": "^2.4.1",
     "react": "^0.12.1",
-    "react-router": "^0.11.4"
+    "react-router": "0.11.x"
   },
   "devDependencies": {
     "autoprefixer-loader": "^1.0.0",


### PR DESCRIPTION
Before our 1.0 release we pretend like the second number is our first, so breaking api changes happen at 0.x, don't want to slip in a breaking api change on you with `^` :)